### PR TITLE
Moved date assignment above filtering.

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -40,6 +40,9 @@ calculate_distances <- function(all_markets, data, id, i, warping_limit, matches
   }
   distances$matches <- matches
   distances$w <- dtw_emphasis
+  distances$MatchingStartDate <- min(dates)
+  distances$MatchingEndDate <- max(dates)
+  
   distances <- dplyr::filter(distances, Skip==FALSE) %>%
     dplyr::mutate(dist_rank=rank(RelativeDistance)) %>%
     dplyr::mutate(corr_rank=rank(-Correlation)) %>%
@@ -50,8 +53,6 @@ calculate_distances <- function(all_markets, data, id, i, warping_limit, matches
     dplyr::filter(rank<=matches) %>%
     dplyr::select(-matches, -w)
 
-  distances$MatchingStartDate <- min(dates)
-  distances$MatchingEndDate <- max(dates)
   return(distances)
 }
 


### PR DESCRIPTION
When `Skip==TRUE` for all rows, then`dplyr::filter(distances, Skip==FALSE)`returns an empty dataframe. This caused the assignment 

`distances$MatchingStartDate <- min(dates)`

to throw the following error:

```
Error in `$<-.data.frame`(`*tmp*`, "MatchingStartDate", value = Inf) : 
  replacement has 1 row, data has 0
```

Moving the date assignment above the filtering line should avoid this error.
