### PR TITLE
More robust distance calculation

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -7,8 +7,8 @@ calculate_distances <- function(all_markets, data, id, i, warping_limit, matches
   ThisMarket <- all_markets[i]
   distances <- data.frame(matrix(nrow=length(all_markets), ncol=5))
   names(distances) <- c(id, "BestControl", "RelativeDistance", "Correlation", "Length")
-  messages <- 0
   for (j in 1:length(all_markets)){
+    isValidTest <- TRUE
     ThatMarket <- all_markets[j]
     distances[row, id] <- ThisMarket
     distances[row, "BestControl"] <- ThatMarket
@@ -16,11 +16,11 @@ calculate_distances <- function(all_markets, data, id, i, warping_limit, matches
     test <- mkts[[1]]
     ref <- mkts[[2]]
     dates <- mkts[[3]]
-    if ((var(test)==0 | length(test)<=2*warping_limit+1) & messages==0){
+    if ((var(test)==0 | length(test)<=2*warping_limit+1)){
       print(paste0("NOTE: test market ", ThisMarket, " has insufficient data or no variance and hence will be excluded"))
-      messages <- messages + 1
+      isValidTest <- FALSE
     }
-    if (ThisMarket != ThatMarket & messages==0 & var(ref)>0 & length(test)>2*warping_limit){
+    if (ThisMarket != ThatMarket & isValidTest==TRUE & var(ref)>0 & length(test)>2*warping_limit){
       if (dtw_emphasis>0){
         dist <- dtw(test, ref, window.type=sakoeChibaWindow, window.size=warping_limit)$distance / abs(sum(test))
       } else{

--- a/R/functions.R
+++ b/R/functions.R
@@ -40,6 +40,9 @@ calculate_distances <- function(all_markets, data, id, i, warping_limit, matches
   }
   distances$matches <- matches
   distances$w <- dtw_emphasis
+  distances$MatchingStartDate <- min(data$date_var)
+  distances$MatchingEndDate <- max(data$date_var)
+  
   distances <- dplyr::filter(distances, Skip==FALSE) %>%
     dplyr::mutate(dist_rank=rank(RelativeDistance)) %>%
     dplyr::mutate(corr_rank=rank(-Correlation)) %>%
@@ -50,8 +53,6 @@ calculate_distances <- function(all_markets, data, id, i, warping_limit, matches
     dplyr::filter(rank<=matches) %>%
     dplyr::select(-matches, -w)
 
-  distances$MatchingStartDate <- min(dates)
-  distances$MatchingEndDate <- max(dates)
   return(distances)
 }
 


### PR DESCRIPTION
Made some changes to make `calculate_distances` more robust to messy input. 
#### Changed Error messaging

I added an `isValidTest` boolean flag to take the place of the old `messages` counter. With the old functionality, as soon as a single test+ref combo had "insufficient data or no variance", then `messages` was incremented and all of the following test+ref combos were set as `Skip <- TRUE`. The new boolean `isValidTest` is reset for each test+ref combo so this should not occur.

The `messages` counter was repurposed to count how many of the test+ref combos are not valid and this number is printed at the end.
#### Changed matching dates

The matching start and end dates are set using the global min and max of the data (e.g. `min(data$date_var)`). This fixed a bug where, since all of the test+ref combos are not necessarily the same length, the `dates` array would sometimes be all null.

The date assignment was also moved above the filtering to avoid possible scenarios where filtering returned 0 rows and an error was thrown on date assignment.
