### PR TITLE
Reduce datasize in best_matches output

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -544,6 +544,9 @@ best_matches <- function(data=NULL, markets_to_be_matched=NULL, id_variable=NULL
     dplyr::filter(shortest_distances, Skip==FALSE) %>%
     dplyr::select(-Skip)
   
+  ### Save reduced data
+  saved_data <- saved_data %>% dplyr::filter(id_var %in% (shortest_distances$ID) | id_var %in% (shortest_distances$BestControl))
+  
   object <- list(BestMatches=shortest_distances, Data=as.data.frame(saved_data), MarketID=id_variable, MatchingMetric=matching_variable, DateVariable=date_variable, SuggestedTestControlSplits=suggested_split, Bins=Sizes)
   class(object) <- "matched_market"
   return (object)


### PR DESCRIPTION
Hi Kim.

**Changes, I've made:**
In the best_matches function, the complete data is saved for each test-market. This can be massively reduced, by filtering for the test-market and the best-control-markets (see pull request).

**Improvement (Example):**
Say I have a pool of 1262 control markets and 10 test markets, for which I want to find (the 5) best matches. For each market I have 52 datapoints. In the best_matches output, I have 65676 datapoints for each market. Combining the ten outputs in a list, results in an object with size ~16MB. With my proposed change, each output only has 312 (the relevant) data points. Size is down to 128KB.

**Benefit:**
Reduced memory need. Also, we've created a power-analysis wrapper (simultaneously to your development, it seems) and simulate across markets, start-points of simulation, etc. The size of the output then increases drastically, up to a point where I've experienced "cannot allocate memory" issues in the inference part when parallelizing the calculation using furrr (future_map).
In an extreme case, I've reduced the object size from 2.5GB to about 26MB.

It's my first pull-request, so I hope that I did everything correctly. If not, please let me know. :)
Thanks for your amazing work. And please let me know what you think of my proposed change. :)

Best
Philipp